### PR TITLE
Implement admin page

### DIFF
--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { AdminPage } from './admin.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: AdminPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AdminPageRoutingModule {}

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { AdminPageRoutingModule } from './admin-routing.module';
+
+import { AdminPage } from './admin.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    AdminPageRoutingModule
+  ],
+  declarations: [AdminPage]
+})
+export class AdminPageModule {}

--- a/src/app/admin/admin.page.html
+++ b/src/app/admin/admin.page.html
@@ -1,0 +1,20 @@
+<ion-content [fullscreen]="true" class="ion-padding">
+  <div class="header-row">
+    <ion-button fill="clear" class="back-button" (click)="goBack()">
+      <ion-icon name="arrow-back-outline" size="large" class="back-icon"></ion-icon>
+    </ion-button>
+    <h3 class="title">Administración</h3>
+  </div>
+
+  <div class="options-container">
+    <div class="option-card" (click)="manageSubjects()">
+      <ion-icon name="book" class="option-icon"></ion-icon>
+      <span>Administrar asignaturas</span>
+    </div>
+
+    <div class="option-card" (click)="manageResources()">
+      <ion-icon name="document-text" class="option-icon"></ion-icon>
+      <span>Administrar recursos</span>
+    </div>
+  </div>
+</ion-content>

--- a/src/app/admin/admin.page.scss
+++ b/src/app/admin/admin.page.scss
@@ -1,0 +1,46 @@
+ion-content {
+  --background: #f8f8f8;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+
+  .back-icon {
+    margin-right: 0.75rem;
+    color: #5b2a9a;
+  }
+  .title {
+    font-weight: bold;
+    margin: 0;
+    color: #5b2a9a;
+  }
+}
+
+.options-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.option-card {
+  background: linear-gradient(to top, #4a0072, #9c27b0);
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  color: white;
+  cursor: pointer;
+  transition: all 0.3s ease;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .option-icon {
+    font-size: 28px;
+    margin-right: 12px;
+  }
+}

--- a/src/app/admin/admin.page.spec.ts
+++ b/src/app/admin/admin.page.spec.ts
@@ -1,0 +1,17 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AdminPage } from './admin.page';
+
+describe('AdminPage', () => {
+  let component: AdminPage;
+  let fixture: ComponentFixture<AdminPage>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/admin.page.ts
+++ b/src/app/admin/admin.page.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-admin',
+  templateUrl: './admin.page.html',
+  styleUrls: ['./admin.page.scss'],
+  standalone: false
+})
+export class AdminPage implements OnInit {
+  constructor(private router: Router) {}
+
+  ngOnInit() {}
+
+  goBack() {
+    this.router.navigate(['/profile']);
+  }
+
+  manageSubjects() {
+    // TODO: implement navigation to subjects management
+    console.log('Navegar a administrar asignaturas');
+  }
+
+  manageResources() {
+    // TODO: implement navigation to resources management
+    console.log('Navegar a administrar recursos');
+  }
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -42,6 +42,10 @@ const routes: Routes = [
     loadChildren: () => import('./profile/profile.module').then( m => m.ProfilePageModule)
   },
   {
+    path: 'admin',
+    loadChildren: () => import('./admin/admin.module').then( m => m.AdminPageModule)
+  },
+  {
     path: 'profile-edit',
     loadChildren: () => import('./profile-edit/profile-edit.module').then( m => m.ProfileEditPageModule)
   },

--- a/src/app/profile/profile.page.html
+++ b/src/app/profile/profile.page.html
@@ -120,4 +120,9 @@
     <ion-icon name="star" slot="start"></ion-icon>
     Apuntes favoritos
   </div>
+
+  <div expand="block" routerLink="/admin" class="favorite-button">
+    <ion-icon name="settings" slot="start"></ion-icon>
+    Administración
+  </div>
 </ion-content>


### PR DESCRIPTION
## Summary
- create new AdminPage with styling consistent across the app
- route `/admin` now loads the new AdminPage
- add navigation from the profile page to the admin section

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca31a08288330ba7a48da4e6636a0