### PR TITLE
Implement admin page

### DIFF
--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { AdminPage } from './admin.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: AdminPage
+  },
+  {
+    path: 'subjects',
+    loadChildren: () => import('./manage-subjects/manage-subjects.module').then(m => m.ManageSubjectsPageModule)
+  },
+  {
+    path: 'resources',
+    loadChildren: () => import('./manage-resources/manage-resources.module').then(m => m.ManageResourcesPageModule)
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AdminPageRoutingModule {}

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { AdminPageRoutingModule } from './admin-routing.module';
+
+import { AdminPage } from './admin.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    AdminPageRoutingModule
+  ],
+  declarations: [AdminPage]
+})
+export class AdminPageModule {}

--- a/src/app/admin/admin.page.html
+++ b/src/app/admin/admin.page.html
@@ -1,0 +1,20 @@
+<ion-content [fullscreen]="true" class="ion-padding">
+  <div class="header-row">
+    <ion-button fill="clear" class="back-button" (click)="goBack()">
+      <ion-icon name="arrow-back-outline" size="large" class="back-icon"></ion-icon>
+    </ion-button>
+    <h3 class="title">Administración</h3>
+  </div>
+
+  <div class="options-container">
+    <div class="option-card" (click)="manageSubjects()">
+      <ion-icon name="book" class="option-icon"></ion-icon>
+      <span>Administrar asignaturas</span>
+    </div>
+
+    <div class="option-card" (click)="manageResources()">
+      <ion-icon name="document-text" class="option-icon"></ion-icon>
+      <span>Administrar recursos</span>
+    </div>
+  </div>
+</ion-content>

--- a/src/app/admin/admin.page.scss
+++ b/src/app/admin/admin.page.scss
@@ -1,0 +1,46 @@
+ion-content {
+  --background: #f8f8f8;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+
+  .back-icon {
+    margin-right: 0.75rem;
+    color: #5b2a9a;
+  }
+  .title {
+    font-weight: bold;
+    margin: 0;
+    color: #5b2a9a;
+  }
+}
+
+.options-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.option-card {
+  background: linear-gradient(to top, #4a0072, #9c27b0);
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  color: white;
+  cursor: pointer;
+  transition: all 0.3s ease;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .option-icon {
+    font-size: 28px;
+    margin-right: 12px;
+  }
+}

--- a/src/app/admin/admin.page.scss
+++ b/src/app/admin/admin.page.scss
@@ -25,18 +25,19 @@ ion-content {
 }
 
 .option-card {
-  background: linear-gradient(to top, #4a0072, #9c27b0);
-  border-radius: 12px;
+  background: linear-gradient(to right, #6a0dad, #9c27b0);
+  border-radius: 16px;
   padding: 20px;
   display: flex;
   align-items: center;
   color: white;
   cursor: pointer;
   transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(106, 13, 173, 0.2);
 
   &:hover {
     transform: translateY(-5px);
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 8px 16px rgba(106, 13, 173, 0.4);
   }
 
   .option-icon {

--- a/src/app/admin/admin.page.spec.ts
+++ b/src/app/admin/admin.page.spec.ts
@@ -1,0 +1,17 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AdminPage } from './admin.page';
+
+describe('AdminPage', () => {
+  let component: AdminPage;
+  let fixture: ComponentFixture<AdminPage>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/admin.page.ts
+++ b/src/app/admin/admin.page.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-admin',
+  templateUrl: './admin.page.html',
+  styleUrls: ['./admin.page.scss'],
+  standalone: false
+})
+export class AdminPage implements OnInit {
+  constructor(private router: Router) {}
+
+  ngOnInit() {}
+
+  goBack() {
+    this.router.navigate(['/profile']);
+  }
+
+  manageSubjects() {
+    this.router.navigate(['/admin/subjects']);
+  }
+
+  manageResources() {
+    this.router.navigate(['/admin/resources']);
+  }
+}

--- a/src/app/admin/manage-resources/manage-resources-routing.module.ts
+++ b/src/app/admin/manage-resources/manage-resources-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { ManageResourcesPage } from './manage-resources.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ManageResourcesPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ManageResourcesPageRoutingModule {}

--- a/src/app/admin/manage-resources/manage-resources.module.ts
+++ b/src/app/admin/manage-resources/manage-resources.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { ManageResourcesPageRoutingModule } from './manage-resources-routing.module';
+
+import { ManageResourcesPage } from './manage-resources.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    ManageResourcesPageRoutingModule
+  ],
+  declarations: [ManageResourcesPage]
+})
+export class ManageResourcesPageModule {}

--- a/src/app/admin/manage-resources/manage-resources.page.html
+++ b/src/app/admin/manage-resources/manage-resources.page.html
@@ -1,0 +1,17 @@
+<ion-content [fullscreen]="true" class="ion-padding">
+  <div class="header-row">
+    <ion-button fill="clear" class="back-button" (click)="goBack()">
+      <ion-icon name="arrow-back-outline" size="large" class="back-icon"></ion-icon>
+    </ion-button>
+    <h3 class="title">Administrar recursos</h3>
+  </div>
+
+  <ion-list>
+    <ion-item *ngFor="let note of notes">
+      <ion-label>{{ note.title }}</ion-label>
+      <ion-button color="danger" fill="clear" (click)="removeNote(note)">
+        <ion-icon slot="icon-only" name="trash"></ion-icon>
+      </ion-button>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/admin/manage-resources/manage-resources.page.scss
+++ b/src/app/admin/manage-resources/manage-resources.page.scss
@@ -1,0 +1,18 @@
+ion-content {
+  --background: #f8f8f8;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  .back-icon {
+    margin-right: 0.5rem;
+    color: #5b2a9a;
+  }
+  .title {
+    font-weight: bold;
+    color: #5b2a9a;
+  }
+}

--- a/src/app/admin/manage-resources/manage-resources.page.ts
+++ b/src/app/admin/manage-resources/manage-resources.page.ts
@@ -1,0 +1,36 @@
+import { Component, OnInit } from '@angular/core';
+import { NotesService, Note } from '../../services/notes.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-manage-resources',
+  templateUrl: './manage-resources.page.html',
+  styleUrls: ['./manage-resources.page.scss'],
+  standalone: false
+})
+export class ManageResourcesPage implements OnInit {
+  notes: Note[] = [];
+
+  constructor(private notesService: NotesService, private router: Router) {}
+
+  ngOnInit() {
+    this.loadNotes();
+  }
+
+  loadNotes() {
+    this.notesService.getPracticeNotes().subscribe((p) => {
+      this.notes = p;
+      this.notesService.getTheoryNotes().subscribe((t) => {
+        this.notes = this.notes.concat(t);
+      });
+    });
+  }
+
+  goBack() {
+    this.router.navigate(['/admin']);
+  }
+
+  removeNote(note: Note) {
+    this.notes = this.notes.filter((n) => n !== note);
+  }
+}

--- a/src/app/admin/manage-subjects/manage-subjects-routing.module.ts
+++ b/src/app/admin/manage-subjects/manage-subjects-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { ManageSubjectsPage } from './manage-subjects.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ManageSubjectsPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ManageSubjectsPageRoutingModule {}

--- a/src/app/admin/manage-subjects/manage-subjects.module.ts
+++ b/src/app/admin/manage-subjects/manage-subjects.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { ManageSubjectsPageRoutingModule } from './manage-subjects-routing.module';
+
+import { ManageSubjectsPage } from './manage-subjects.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    ManageSubjectsPageRoutingModule
+  ],
+  declarations: [ManageSubjectsPage]
+})
+export class ManageSubjectsPageModule {}

--- a/src/app/admin/manage-subjects/manage-subjects.page.html
+++ b/src/app/admin/manage-subjects/manage-subjects.page.html
@@ -1,0 +1,22 @@
+<ion-content [fullscreen]="true" class="ion-padding">
+  <div class="header-row">
+    <ion-button fill="clear" class="back-button" (click)="goBack()">
+      <ion-icon name="arrow-back-outline" size="large" class="back-icon"></ion-icon>
+    </ion-button>
+    <h3 class="title">Administrar asignaturas</h3>
+  </div>
+
+  <div class="add-row">
+    <ion-input placeholder="Nueva asignatura" [(ngModel)]="newName"></ion-input>
+    <ion-button (click)="addSubject()">Añadir</ion-button>
+  </div>
+
+  <ion-list>
+    <ion-item *ngFor="let subject of subjects">
+      <ion-label>{{ subject.name }}</ion-label>
+      <ion-button color="danger" fill="clear" (click)="removeSubject(subject)">
+        <ion-icon slot="icon-only" name="trash"></ion-icon>
+      </ion-button>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/admin/manage-subjects/manage-subjects.page.scss
+++ b/src/app/admin/manage-subjects/manage-subjects.page.scss
@@ -1,0 +1,24 @@
+ion-content {
+  --background: #f8f8f8;
+}
+
+.header-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+
+  .back-icon {
+    margin-right: 0.5rem;
+    color: #5b2a9a;
+  }
+  .title {
+    font-weight: bold;
+    color: #5b2a9a;
+  }
+}
+
+.add-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}

--- a/src/app/admin/manage-subjects/manage-subjects.page.ts
+++ b/src/app/admin/manage-subjects/manage-subjects.page.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import { CourseDataService, Subject } from '../../services/course-data.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-manage-subjects',
+  templateUrl: './manage-subjects.page.html',
+  styleUrls: ['./manage-subjects.page.scss'],
+  standalone: false
+})
+export class ManageSubjectsPage implements OnInit {
+  subjects: Subject[] = [];
+  newName = '';
+
+  constructor(private courseData: CourseDataService, private router: Router) {}
+
+  ngOnInit() {
+    for (let year = 1; year <= 4; year++) {
+      this.courseData.getSubjectsByCourseYear(year).subscribe((subs) => {
+        this.subjects = [...this.subjects, ...subs];
+      });
+    }
+  }
+
+  goBack() {
+    this.router.navigate(['/admin']);
+  }
+
+  addSubject() {
+    const name = this.newName.trim();
+    if (!name) return;
+    const newSubject: Subject = { id: Date.now(), name, icon: '' };
+    this.subjects.push(newSubject);
+    this.newName = '';
+  }
+
+  removeSubject(sub: Subject) {
+    this.subjects = this.subjects.filter((s) => s !== sub);
+  }
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -42,6 +42,10 @@ const routes: Routes = [
     loadChildren: () => import('./profile/profile.module').then( m => m.ProfilePageModule)
   },
   {
+    path: 'admin',
+    loadChildren: () => import('./admin/admin.module').then( m => m.AdminPageModule)
+  },
+  {
     path: 'profile-edit',
     loadChildren: () => import('./profile-edit/profile-edit.module').then( m => m.ProfileEditPageModule)
   },

--- a/src/app/profile/profile.page.html
+++ b/src/app/profile/profile.page.html
@@ -120,4 +120,9 @@
     <ion-icon name="star" slot="start"></ion-icon>
     Apuntes favoritos
   </div>
+
+  <div expand="block" routerLink="/admin" class="favorite-button">
+    <ion-icon name="settings" slot="start"></ion-icon>
+    Administración
+  </div>
 </ion-content>


### PR DESCRIPTION
## Summary
- create new AdminPage with styling consistent across the app
- route `/admin` now loads the new AdminPage
- add navigation from the profile page to the admin section
- add subpages to manage subjects and resources from admin area

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca31a08288330ba7a48da4e6636a0