### PR TITLE
Add admin subpage navigation

### DIFF
--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -7,7 +7,20 @@ const routes: Routes = [
   {
     path: '',
     component: AdminPage
-
+  },
+  {
+    path: 'manage-subjects',
+    loadChildren: () =>
+      import('./manage-subjects/manage-subjects.module').then(
+        (m) => m.ManageSubjectsPageModule
+      )
+  },
+  {
+    path: 'manage-resources',
+    loadChildren: () =>
+      import('./manage-resources/manage-resources.module').then(
+        (m) => m.ManageResourcesPageModule
+      )
   }
 ];
 

--- a/src/app/admin/admin.page.ts
+++ b/src/app/admin/admin.page.ts
@@ -17,6 +17,10 @@ export class AdminPage implements OnInit {
   }
 
   manageSubjects() {
+    this.router.navigate(['/admin/manage-subjects']);
+  }
 
+  manageResources() {
+    this.router.navigate(['/admin/manage-resources']);
   }
 }


### PR DESCRIPTION
## Summary
- enable navigation to manage subjects and resources from Admin page
- register child routes for managing subjects and resources

## Testing
- `npx ng test --watch=false` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684cba9cc6788330a94322f6659ed857